### PR TITLE
Improved README. Added jscs and some eslint rule explanations

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,6 +27,31 @@ project's `package.json` manifest file, like so:
 ... and then you can invoke it by executing `npm run lint`.
 
 
+Linting Support in Text Editors
+-------------------------------
+
+With linting rules moved to an npm module, linters such as [SublimeLinter][sl]
+for Sublime Text, [syntastic][syn] for vim and [flycheck][fc] for emacs, will
+be unable to to find the lint-trap linting rules for the project.
+
+In the short term this can be fixed by copying those files from lint-trap to
+your project and adding them to your `.gitignore`. From the root of your
+project:
+
+    cp ./node_modules/lint-trap/lib/rc/.{jscs,eslint,jshint}rc .
+    rc=( .{jscs,eslint,jshint}rc )
+    for c in "${rc[@]}"; do echo $c >> .gitignore; done;
+
+Symlinking was preferred here, but SublimeLinter won't load symlinked linter
+configuration files.
+
+In the future, we will have lint-trap plugin for lint-trap so that you don't
+need to install plugins for all the linters that lint-trap supports. In the
+meantime, you should consult the documentation for the linting engine available
+for your code editor to discover how to enable support for jscs, jshint and
+eslint.
+
+
 Overriding Rules
 ----------------
 
@@ -96,6 +121,45 @@ include the following two modules in your project:
  - https://github.com/defunctzombie/node-process
 
 
+Contributing
+------------
+
+Contributions to lint-trap are welcome, but since lint-trap is effectively a
+module that encapsulates a set of opinions and throws errors and warnings at
+you when you violate those opinions, there is a lot of room to debate over
+[what color to paint our bikeshed][bikeshed].
+
+Before you begin filing an issue to argue why you think your color of paint is
+superior, it's worth knowing how the current set of rules were determined. The
+engineers on web core, realtime developer productivity and dispatch/realtime
+teams were the first to go through all the rules and debate the merit of each.
+This group is consists of developers that collectively have seen tons of code
+and tons of bugs in production systems that arose from poor choice of coding 
+style and conventions.
+
+The rules and the reasoning behind each should all be documented or will be
+over time. Before we bikeshed over a rule, please check the rules
+[documentation][docs]. If a rule hasn't been documented or hasn't yet been
+documented adequately, open an issue asking for clarification and better 
+documentation *first*. If a rule has been documented and you still disagree,
+feel free to bikeshed. We all love bikeshedding, but we would like to keep it
+to a minimum.
+
+
+[sl]: http://sublimelinter.readthedocs.org/
+[syn]: https://github.com/scrooloose/syntastic
+[fc]: http://flycheck.readthedocs.org/
+
+[sl-jshint]: https://github.com/SublimeLinter/SublimeLinter-jshint
+[sl-jscs]: https://github.com/SublimeLinter/SublimeLinter-jscs/
+[sl-eslint]: https://github.com/roadhump/SublimeLinter-eslint
+
+[syn-jshint]: https://github.com/scrooloose/syntastic/wiki/JavaScript%3A---jshint
+[syn-jscs]: https://github.com/scrooloose/syntastic/wiki/JavaScript%3A---jscs
+[syn-eslint]: https://github.com/scrooloose/syntastic/wiki/JavaScript%3A---eslint
+
+[fs-javascript]: http://flycheck.readthedocs.org/en/latest/guide/languages.html#javascript
+
 [configuring-eslint]: http://eslint.org/docs/configuring/
 [configuring-jshint]: http://www.jshint.com/docs/
 [configuring-jscs]: https://github.com/jscs-dev/node-jscs#error-suppression
@@ -104,3 +168,4 @@ include the following two modules in your project:
 [docs]: https://github.com/uber/lint-trap/tree/master/docs
 [wadlers-law]: http://www.haskell.org/haskellwiki/Wadler's_Law
 [set-indent-rule.js]: https://github.com/uber/lint-trap/blob/master/set-indent-rule.js
+[bikeshed]: http://red.bikeshed.com/

--- a/docs/eslint.md
+++ b/docs/eslint.md
@@ -1,0 +1,377 @@
+# ESLint guidelines.
+
+## Status quo.
+
+### Environments
+
+    "env": {
+        "browser": false,
+        "node": false,
+        "amd": false,
+        "mocha": false,
+        "jasmine": false
+    }
+
+None of the environment meta variables are used because we proscribe our own
+style, which applies to both server side and browser side code. The most
+important issue to be aware of here is how we handle globals explained below.
+
+
+### Globals
+
+    "globals": {
+        "__dirname": true,
+        "__filename": true,
+        "require": true,
+        "module": true
+    },
+
+
+This is the minimum set of globals required both in the browser and in NodeJS.
+Restricting globals to this set has numerous benefits:
+ - It trains developers to never rely on global scope
+ - It reduces the length of the scope chain that needs to be traversed since
+   pointers to a global object are encountered sooner in the chain.
+ - Allows globals to be mocked in testing environments.
+
+Please see the section titled "Globals" in the [README][readme] for further
+information.
+
+
+## Rules
+
+    "no-alert": 2
+
+The `alert` function blocks JavaScript execution. Also, modal dialogs where the
+user can only ever press OK to acknowledge them is a huge UI anti-pattern.
+
+    "no-array-constructor": 2
+
+[Official ESLint Explanation][no-array-constructor]
+
+    "no-bitwise": 0
+
+    "no-caller": 2
+
+    "no-catch-shadow": 2
+
+    "no-comma-dangle": 2
+
+    "no-cond-assign": 2
+
+    "no-console": 2
+
+    "no-constant-condition": 2
+
+    "no-control-regex": 2
+
+    "no-debugger": 2
+
+    "no-delete-var": 2
+
+    "no-div-regex": 0
+
+    "no-dupe-keys": 2
+
+    "no-else-return": 0
+
+    "no-empty": 2
+
+    "no-empty-class": 2
+
+    "no-empty-label": 2
+
+    "no-eq-null": 0
+
+    "no-eval": 2
+
+    "no-ex-assign": 2
+
+    "no-extend-native": 2
+
+    "no-extra-bind": 2
+
+    "no-extra-boolean-cast": 2
+
+    "no-extra-parens": 0
+
+    "no-extra-semi": 2
+
+    "no-extra-strict": 2
+
+    "no-fallthrough": 2
+
+    "no-floating-decimal": 0
+
+    "no-func-assign": 2
+
+    "no-implied-eval": 2
+
+    "no-inner-declarations": [2, "functions"]
+
+    "no-invalid-regexp": 2
+
+    "no-iterator": 2
+
+    "no-label-var": 2
+
+    "no-labels": 2
+
+    "no-lone-blocks": 2
+
+    "no-lonely-if": 0
+
+    "no-loop-func": 2
+
+    "no-mixed-requires": [0, false]
+
+    "no-mixed-spaces-and-tabs": [2, false]
+
+    // "no-multi-spaces": 2
+
+    "no-multi-str": 2
+
+    "no-multiple-empty-lines": [0, {"max": 2}]
+
+    "no-native-reassign": 2
+
+    "no-negated-in-lhs": 2
+
+    "no-nested-ternary": 0
+
+    "no-new": 2
+
+    "no-new-func": 2
+
+    "no-new-object": 2
+
+    "no-new-require": 0
+
+    "no-new-wrappers": 2
+
+    "no-obj-calls": 2
+
+    "no-octal": 2
+
+    "no-octal-escape": 2
+
+    "no-path-concat": 0
+
+    "no-plusplus": 0
+
+    "no-process-env": 0
+
+    "no-process-exit": 2
+
+    "no-proto": 2
+
+    "no-redeclare": 2
+
+    "no-regex-spaces": 2
+
+    "no-reserved-keys": 0
+
+    "no-restricted-modules": 0
+
+    "no-return-assign": 2
+
+    "no-script-url": 2
+
+    "no-self-compare": 0
+
+    "no-sequences": 2
+
+    "no-shadow": 2
+
+    "no-shadow-restricted-names": 2
+
+    "no-space-before-semi": 2
+
+    "no-spaced-func": 2
+
+    "no-sparse-arrays": 2
+
+    "no-sync": 0
+
+    "no-ternary": 0
+
+    "no-trailing-spaces": 2
+
+    "no-undef": 2
+
+    "no-undef-init": 2
+
+    "no-undefined": 0
+
+    "no-underscore-dangle": 2
+
+    "no-unreachable": 2
+
+    "no-unused-expressions": 2
+
+    "no-unused-vars": [2, {"vars": "all", "args": "none"}]
+
+    "no-use-before-define": [2, "nofunc"]
+
+    "no-void": 0
+
+    "no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }]
+
+    "no-with": 2
+
+    "no-wrap-func": 2
+
+    "block-scoped-var": 0
+
+    "brace-style": [0, "1tbs"]
+
+    "camelcase": 2
+
+    "comma-style": 0
+
+    "complexity": [0, 11]
+
+    "consistent-return": 2
+
+    "consistent-this": [0, "that"]
+
+    "curly": [2, "all"]
+
+    "default-case": 0
+
+    "dot-notation": 2
+
+    "eol-last": 2
+
+    "eqeqeq": 2
+
+    "func-names": 2
+
+This rules requires you to name every function. The purpose of forcing you to
+always name every function is two-fold. First, this produces much more readable
+stack traces, since anonymous function calls require you to go to the source
+code and figure out what a function is trying to do. Naming the function makes
+it clear what it is trying to do. Second, naming your functions, makes it easy
+to pull out the function from where is is being called, thereby keeping
+indentation levels and line lengths low.
+
+One thing to keep in mind with this rule is that named function expressions are
+not hoisted into the current scope. For example, in the following line of code
+only `foo` will be available in the top-level scope, and `bar` will only be
+available within its own scope. 
+
+    var foo = function bar() {};
+
+Furthermore, when you write inline functions (which are oftern anonymous
+functions), those functions are function expressions, not function
+declarations. What this means is that in a test file, it is perfectly
+acceptable to do the following since the function expressions with name `t`
+do not collide in the same scope as the token `test`:
+
+    var test = require('tape');
+
+    test('foo', function t() { /* test foo */ });
+    test('bar', function t() { /* test bar */ });
+    test('baz', function t() { /* test baz */ });
+
+If appropriate, you can also name those function expressions more explicitly,
+like `tFoo`, `tBar` and `tBaz`, but this is not necessary.
+
+In the case of anonymous callback functions used for the sole purpose of
+handling the first error argument, before calling another function with the
+remaining arguments, you can name it something like `handleError` or you can
+even use a helper function like the following to wrap the error if you find
+yourself writing lots of `handleError` callback functions in the same file:
+
+    function wrapError(callbackFn, nextFn) {
+        return function handleError(err) {
+            if (err) {
+                return callbackFn(err);
+            }
+            var args = arguments.slice(1);
+            args.push(callbackFn);
+            nextFn.apply(null, args);
+        }
+    }
+
+Overall, this rule that requires that all functions be named may same tedious
+at first, but it almost invariably forces you to refactor a lot of your code
+for the better, since it prevents you from abusing lambdas. If you encounter
+a use case where you think it is particularly challenging to satisfy this rule,
+feel free to open up an issue, and we'll help you figure out how refactor your
+code.
+
+
+    "func-style": [0, "declaration"]
+
+    "global-strict": [2, "always"]
+
+    "guard-for-in": 0
+
+    "handle-callback-err": 0
+
+    // "key-spacing": [2, { "beforeColon": false, "afterColon": true }]
+
+    "max-depth": [0, 4]
+
+    "max-len": [0, 80, 4]
+
+    "max-nested-callbacks": [0, 2]
+
+    "max-params": [0, 3]
+
+    "max-statements": [0, 10]
+
+    "new-cap": [2, { newIsCap: true, capIsNew: false }]
+
+    "new-parens": 2
+
+    "one-var": 0
+
+    "padded-blocks": 0
+
+    "quote-props": 0
+
+    "quotes": [2, "single"]
+
+    "radix": 0
+
+    "semi": 2
+
+    "sort-vars": 0
+
+    "space-after-keywords": [0, "always"]
+
+    "space-before-blocks": [0, "always"]
+
+    "space-in-brackets": [0, "never"]
+
+    "space-in-parens": [0, "never"]
+
+    "space-infix-ops": 2
+
+    "space-return-throw-case": 2
+
+    "space-unary-word-ops": 0
+
+    "spaced-line-comment": [0, "always"]
+
+    "strict": 2
+
+    "use-isnan": 2
+
+    "valid-jsdoc": 0
+
+    "valid-typeof": 2
+
+    "vars-on-top": 0
+
+    "wrap-iife": 0
+
+    "wrap-regex": 0
+
+    "yoda": [2, "never"]
+
+
+[readme]: https://github.com/uber/lint-trap/blob/master/README.markdown
+[no-array-constructor]: https://github.com/eslint/eslint/blob/master/docs/rules/no-array-constructor.md

--- a/docs/jscs.md
+++ b/docs/jscs.md
@@ -1,0 +1,286 @@
+# jscs guidelines.
+
+## Status quo.
+
+    "validateIndentation": 4
+
+While the default value is 4, this rule is dynamically generated based on the
+indentation style already used in a project.
+
+
+    "maximumLineLength": {
+        "value": 80
+    }
+
+Long lines make code harder to read and are usually indicative of poor quality
+code. Also, since 80-character lines has been a common standard across many
+languages for so long, many developers have optimized their development 
+workflow to use 80-character code editor windows and panes.
+
+
+    "maximumLineLength": {
+        "allowUrlComments": true
+    }
+
+Many URLs are longer than 80 characters long. Breaking them across multiple
+lines doesn't make sense because they no longer can easily be copied and
+pasted. Ideally 
+
+If you have a URL that is longer than 80 characters, you can use a URL
+shortener like http://t.uber.com/
+
+
+    "maximumLineLength": {
+        "allowUrlComments": false
+    }
+
+Like lines of code, comments are also harder to read and may extend beyond the
+edges of a programmer's code editor windows/panes if they are too long. 
+
+
+    "maximumLineLength": {
+        "allowRegex": false
+    }
+
+If a regex is longer than 80 characters, it is too long to understand. No Regex
+should ever be this long. If you have a long Regex that you got from somewhere,
+it is recommended that you break it up over several lines with comments like
+the one on this page for detecting UTF-8:
+http://www.w3.org/International/questions/qa-forms-utf-8.en.php
+
+
+    "requireSpaceAfterKeywords": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "switch",
+        "return",
+        "try",
+        "catch"
+    ]
+
+Requiring spaces after the keywords above makes the code more readable.
+
+
+    "disallowSpacesInFunctionDeclaration": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInNamedFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "requireSpacesInFunctionDeclaration": {
+        "beforeOpeningCurlyBrace": true
+    },
+    "requireSpacesInNamedFunctionExpression": {
+        "beforeOpeningCurlyBrace": true
+    },
+
+Together with the eslint rule `func-names`, the above rules make sure that
+every single function (declaration or expression) is named and that there is a
+space between the `function` keyword and your function name, no space between
+your function name and the opening parenthesis and that there is always a
+space between the closing arguments parenthesis and the opening function body
+curly bracket.
+
+
+    "disallowTrailingComma": true
+
+Trailing commas are always unnecessary and can cause parsing issues in some
+tools.
+
+
+    "requireBlocksOnNewline": true
+
+This improves readability in 99% of cases. Pretty much the only case in which
+readability is reduced is single-line `if` statements, and even then some will
+argue that `if` statements with only one line in its block is more readable
+with newlines.
+
+
+    "requireCurlyBraces": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "try",
+        "catch",
+        "case",
+        "default"
+    ]
+
+Requiring curly braces makes explicit what code is being handled by the special
+keywords above, removing any potential ambiguities. Furthermore, requiring
+curly braces eliminates a common source of errors where code is inadvertedly
+included or excluded from code block due to indentation/formatting errors.
+
+
+    "disallowMultipleVarDecl": true
+
+This rule enforces consistency and eliminates a source of runtime bugs when a
+comma-separated variable declaration list is modified, resulting in a missing
+comma or extraneous comma.
+
+
+    "disallowEmptyBlocks": true
+
+Missing blocks are either a sign that a developer intended to do something, but
+forgot to implement it or its a sign that a developer is not following the
+[YAGNI][yagni] rule. The only case where it's appropriate to have an empty
+block is `function noop() {};`.
+
+
+    "disallowSpaceAfterObjectKeys": true
+
+This rule enforces consistency that is pretty much the status quo in the
+JavaScript community and the format that pretty much every JSON stringifier
+uses.
+
+
+    "requireCommaBeforeLineBreak": true
+
+This rule enforces consistency that is pretty much the status quo in the
+JavaScript community and the format that pretty much every JSON stringifier
+uses.
+
+
+    "requireSpaceBeforeBinaryOperators": [
+        "+",
+        "-",
+        "/",
+        "*",
+        "=",
+        "==",
+        "===",
+        "!=",
+        "!=="
+    ],
+    "requireSpacesInConditionalExpression": true,
+    "requireSpaceAfterBinaryOperators": [
+        "+",
+        "-",
+        "/",
+        "*",
+        "=",
+        "==",
+        "===",
+        "!=",
+        "!==",
+        ","
+    ]
+
+Collectively, the above rules about requiring spacing around infix binary
+operators introduces whitespace that improves the readability of mathematical
+expressions and equality checks.
+
+
+    "disallowSpaceAfterPrefixUnaryOperators": [
+        "++",
+        "--",
+        "+",
+        "-",
+        "~",
+        "!"
+    ]
+
+Prefix unary operators are more readable when they are in close proximity to
+the object they operate on.
+
+
+    "disallowKeywords": [
+        "with",
+        "try",
+        "catch",
+        "finally"
+    ]
+
+The `with` keyword is generally [considered harmful][with-considered-harmful],
+although there are a few extreme cases where it might be useful. [1][with1]
+[2][with2]
+
+In JavaScript, and especially NodeJS, you should only ever throw an error when
+a programmer has made and error (i.e. a bug). For operational errors, the error
+should be returned to the callee, who can then determine how to handle it. The
+only exception to this rule is using `JSON.parse` with malformed JSON or
+`JSON.stringify` on an object with circular dependencies. 
+
+In the case of parsing and stringifying JSON, we recommend that you use the
+[raynos/safe-json-parse][safe-json-parse]. If you are parsing after reading a
+JSON file or stringifying before writing a JSON file, you may want to use the
+[jprichardson/node-jsonfile][jsonfile] module to simplify things further.
+
+If you find yourself using a library that is throwing on anything other than
+programmer errors (logic errors), then it is a good sign that that library is
+poorly written and you should be using something else.
+
+
+    "disallowMultipleLineBreaks": true
+
+If you require multiple line breaks (beyond one empty line), it is almost
+always an extra unnecessary line or a sign that you should include comments to
+explain in words why two sections are different. Whitespace alone conveys that
+one thing is separate from another, but does not convery *why*.
+
+
+    "validateLineBreaks": "LF"
+
+All line breaks should follow the Multics, Unix and Unix-like system standard
+for newlines.
+
+
+    "validateQuoteMarks": {
+        "mark": "'",
+        "escape": true
+    }
+
+All strings should use single quotes, however double quotes are allowed only in
+cases where the string contains single quotes and the developer would like to
+avoid having to escape them. The goal is consistency with an exception made for
+readability.
+
+
+    "disallowMixedSpacesAndTabs": true
+
+This rule requires no explanation.
+
+
+    "disallowTrailingWhitespace" : true
+
+Trailing whitespaces are unnecessary and disallowing them altogether helps
+eliminate a common source of unnecessary diffs in git commits.
+
+
+    "disallowKeywordsOnNewLine": [
+        "else"
+    ]
+
+Since the `requireBlocksOnNewline` rule is already enforced, allowing `else` to
+occur on a newline would reduce readability.
+
+
+    "requireLineFeedAtFileEnd": true
+
+This improves readability so the last line is not at the edge of your code
+editor buffer right next to your modeline or window status bar without some
+whitespace.
+
+
+    "requireDotNotation": true
+
+All objects should be accessed via dot notation unless the object key cannot be
+expressed in dot notation. This makes code more readable and maximally
+minifiable. The only legitimate reason to revisit this rule is to allow us to
+use Google's Closure Compiler in advanced compression mode.
+
+
+
+
+
+
+[yagni]: http://en.wikipedia.org/wiki/You_aren't_gonna_need_it
+[with-considered-harmful]: http://yuiblog.com/blog/2006/04/11/with-statement-considered-harmful/
+[with1]: http://webreflection.blogspot.com/2009/12/with-worlds-most-misunderstood.html
+[with2]: http://webreflection.blogspot.com/2009/12/with-some-good-example.html
+[safe-json-parse]: https://github.com/Raynos/safe-json-parse


### PR DESCRIPTION
Added explanations for the jscs rules and started documenting the eslint rules.

I did not follow the same readme format as the jshint docs because the jscs rule set includes many rules that are best explained as a set over multiple lines and therefore don't make sense formatted as a heading. We can discuss how best to format the rules documentation in a later commit once most of the explanations for all three linters have been written.

@Raynos @kriskowal @Matt-Esch 
