### PR TITLE
Bump jscs to 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "extend": "^2.0.0",
     "find-parent-dir": "^0.3.0",
     "fstream-ignore": "~1.0.2",
-    "jscs": "~1.8.1",
+    "jscs": "^1.10.0",
     "jshint": "~2.5.6",
     "jsonfile": "~2.0.0",
     "jsonstream2": "^1.1.0",


### PR DESCRIPTION
jscs 1.8.1 uses the generated unicode data (https://github.com/mathiasbynens/node-unicode-data), which adds about 128 megabytes to the dependency chain. This has been reverted in https://github.com/jscs-dev/node-jscs/commit/ec370620d2d0904b7c8133dfcd3a507400343936