### PR TITLE
Turn off the required param description.

### DIFF
--- a/rc/.eslintrc
+++ b/rc/.eslintrc
@@ -150,7 +150,7 @@
         "spaced-line-comment": [2, "always"],
         "strict": 2,
         "use-isnan": 2,
-        "valid-jsdoc": [2, { "requireReturn": false }],
+        "valid-jsdoc": [2, { "requireReturn": false, "requireParamDescription": false }],
         "valid-typeof": 2,
         "vars-on-top": 0,
         "wrap-iife": 2,


### PR DESCRIPTION
Summary: Having an insightful comment for a function parameter is often 
critical, but when the parameters to a function are well named and 
self-explanatory, adding a redundant description just adds noise to the 
docs and creates more work for both the author and the consumer. 
For example:

In a function named 'divide'
* @param {number} numerator - the numerator

In a function named 'getTrip'
* @param {string} tripUuid - the uuid of the trip

Please don't make these comments mandatory.
Setting the configuration based on: http://eslint.org/docs/rules/valid-jsdoc.html