### PR TITLE
Add hack to allow users to easily use more than linttrap

### DIFF
--- a/extras/linttrap.vim
+++ b/extras/linttrap.vim
@@ -35,6 +35,10 @@ function! SyntaxCheckers_javascript_linttrap_GetLocList() dict
 
     let makeprg = self.makeprgBuild({ 'args_before': '--reporter=compact' })
 
+    if !exists('b:syntastic_checkers')
+        let b:syntastic_checkers = ["linttrap"]
+    endif
+
     let errorformat =
         \ '%E%f: line %l\, col %c\, Error - %m,' .
         \ '%W%f: line %l\, col %c\, Warning - %m'


### PR DESCRIPTION
So in the real world people have to use other linters in other projects, there fore they want to put something like:
```
let g:syntastic_javascript_checkers = ["jshint", "linttrap"]
```
in their vimrc.

What this hack does is make it so that if linttrap ends up available (installed in a project), it'll set the buffer's checkers to be only linttrap on first pass.  So you'll still get a bunch of duplicate lint errors on first check, but there-after it'll be only linttrap.

If we could sort out a way to set `b:syntastic_checkers` before first check, then it'd be even better.

cc @rf @malandrew 