### PR TITLE
Modify Syntastic plugin to ignore incorrect file paths.

### DIFF
--- a/extras/linttrap.vim
+++ b/extras/linttrap.vim
@@ -40,12 +40,13 @@ function! SyntaxCheckers_javascript_linttrap_GetLocList() dict
     endif
 
     let errorformat =
-        \ '%E%f: line %l\, col %c\, Error - %m,' .
-        \ '%W%f: line %l\, col %c\, Warning - %m'
+        \ '%E%.%#: line %l\, col %c\, Error - %m,' .
+        \ '%W%.%#: line %l\, col %c\, Warning - %m'
 
     let loclist = SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
+        \ 'defaults': { 'bufnr': bufnr('') },
         \ 'postprocess': ['guards'] })
 
     for e in loclist


### PR DESCRIPTION
Fixes the bug where jumping to an error in the location list doesn't jump to the correct file, if the file being edited lives beyond `./`.

This happens because lint-trap excludes the target dir when listing errors, instead of reporting the relative path starting from the working dir.
